### PR TITLE
feat: Deprecating the library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,12 @@
 PySeascape library
 ******************
 
+⚠️ Warning
+-----------
+
+This library is deprecated; it will no longer be maintained and will not receive further updates.
+
+
 |pyansys| |python| |pypi| |GH-CI| |build| |MIT| |black|
 
 .. |pyansys| image:: https://img.shields.io/badge/Py-Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5mD8vE7q/3bpVyskbW0sMRUwofHD7Dh5OBkZGBgW7/3W2tZpa2tLQEOyOzeEsfumlK2tbVpaGj4N6jIs1lpsDAwMJ278sveMY2BgCA0NFRISwqkhyQ1q/Nyd3zg4OBgYGNjZ2ePi4rB5loGBhZnhxTLJ/9ulv26Q4uVk1NXV/f///////69du4Zdg78lx//t0v+3S88rFISInD59GqIH2esIJ8G9O2/XVwhjzpw5EAam1xkkBJn/bJX+v1365hxxuCAfH9+3b9/+////48cPuNehNsS7cDEzMTAwMMzb+Q2u4dOnT2vWrMHu9ZtzxP9vl/69RVpCkBlZ3N7enoDXBwEAAA+YYitOilMVAAAAAElFTkSuQmCC

--- a/doc/source/general/index.rst
+++ b/doc/source/general/index.rst
@@ -1,3 +1,8 @@
+.. warning::
+
+   This library is deprecated; it will no longer be maintained and will not receive further updates.
+
+
 ******************
 PySeascape library
 ******************

--- a/src/ansys/seascape/__init__.py
+++ b/src/ansys/seascape/__init__.py
@@ -20,10 +20,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# from . scapp import package, bqm_current, deco
+import warnings
+
 from .redhawk import RedHawkSC
 from .utils import include, write_to_file
 
-# from . scapp import package, bqm_current, deco
-
+warnings.warn(
+    "This library is deprecated; it will no longer be maintained and will not receive further updates.",
+    DeprecationWarning,
+)
 
 __version__ = "0.3.dev0"


### PR DESCRIPTION
This PR is performing the following changes in the context of the project's deprecation:
* Updating the `README.rst` file: A short notice is included at the top of the file to inform users that the library is deprecated. I am not using a warning directive here as these do not seem to be rendered correctly in `.rst` files by Github (see https://github.com/ansys/pyadditive-widgets for instance - issue discussed also [here](https://github.com/github/markup/issues/1682) and in multiple related threads),
* Updating the project's `__init__.py` file: Adding a warning in the code to inform users that the library is deprecated, using the Python's `warning` module.
* Updating the project's documentation: Adding the same deprecation notes to the landing page of the documentation. Here a warning directive is being used.

In all these files, the deprecation message is kept minimal, as discussed internally. 
These messages do not provide a link to the deprecation issue because this one intentionally contains no additional information to which users could be directed.